### PR TITLE
Generalized Gaussian blur

### DIFF
--- a/shaders/gl/blur.frag
+++ b/shaders/gl/blur.frag
@@ -5,6 +5,10 @@ layout (binding = 0) uniform sampler2D tex;
 
 layout (location = 0) uniform vec2 size;
 layout (location = 1) uniform vec2 mult;
+layout (location = 2) uniform int kHalfWidth;
+// Maximum length of gauss kernel sample = 100
+layout (location = 3) uniform float[100] offset;
+layout (location = 103) uniform float[100] weight;
 
 in vec2 pass_tc;
 
@@ -19,7 +23,8 @@ vec4 contribute(float offset, float weight)
 
 void main()
 {
-  out_color = texture(tex, pass_tc) * 0.22702703;
-  out_color += contribute(1.38461538, 0.31621622);
-  out_color += contribute(3.23076923, 0.07027027);
+  out_color = texture(tex, pass_tc) * weight[0];
+  for(int i = 1; i < kHalfWidth; i++){
+    out_color += contribute(offset[i], weight[i]);
+  }
 }

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -272,22 +272,22 @@ void RendererGL::render(glm::mat4 proj_mat, glm::mat4 view_mat) {
 
    // Blur pingpong (N horizontal blurs then N vertical blurs)
 
-   if (1) {
-      int loop = 0;
-      for (int i = 0; i < 2; ++i) {
-         if (i == 0)
-            glProgramUniform2f(programBlur.getId(), 1, 1, 0);
-         else
-            glProgramUniform2f(programBlur.getId(), 1, 0, 1);
-         for (int j = 0; j < 1; ++j) {
-            GLuint fbo = fbos[(loop % 2) + 1];
-            GLuint attach = attachs[loop ? ((loop + 1) % 2 + 1) : 0];
-            glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-            glBindTextureUnit(0, attach);
-            glDrawArrays(GL_TRIANGLES, 0, 3);
-            loop++;
-         }
+   const int nPasses = 1; // Only one blur pass in each direction
+   int loop = 0;
+   for (int i = 0; i < 2; ++i) {
+      if (i == 0)
+         glProgramUniform2f(programBlur.getId(), 1, 1, 0);
+      else
+         glProgramUniform2f(programBlur.getId(), 1, 0, 1);
+      for (int j = 0; j < nPasses; ++j) {
+         GLuint fbo = fbos[(loop % 2) + 1];
+         GLuint attach = attachs[loop ? ((loop + 1) % 2 + 1) : 0];
+         glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+         glBindTextureUnit(0, attach);
+         glDrawArrays(GL_TRIANGLES, 0, 3);
+         loop++;
       }
+   }
    }
 
    // Average luminance

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -7,6 +7,8 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <stdexcept>
+#include <iostream>
+#include <numeric>
 
 #include "imgui.h"
 #include "imgui_impl_glfw.h"
@@ -232,6 +234,16 @@ void RendererGL::setUniforms() {
    // Blur sample offset length
    glProgramUniform2f(programBlur.getId(), 0, (float)blurDownscale / width_,
                       (float)blurDownscale / height_);
+
+   // Compute optimized 1D gaussian kernel & send to device
+   auto optimGauss = optimGaussKernel(gaussKernel(10.0, 25));
+   auto offsets = optimGauss.first;
+   auto weights = optimGauss.second;
+
+   assert(offsets.size() < 100 && "Maximum Gaussian kernel size exceeded!");
+   glProgramUniform1i(programBlur.getId(), 2, offsets.size());
+   glProgramUniform1fv(programBlur.getId(), 3, offsets.size(), offsets.data());
+   glProgramUniform1fv(programBlur.getId(), 103, offsets.size(), weights.data());
 }
 
 void RendererGL::render(glm::mat4 proj_mat, glm::mat4 view_mat) {
@@ -259,14 +271,15 @@ void RendererGL::render(glm::mat4 proj_mat, glm::mat4 view_mat) {
    glUseProgram(programBlur.getId());
 
    // Blur pingpong (N horizontal blurs then N vertical blurs)
-   if (0) {
+
+   if (1) {
       int loop = 0;
       for (int i = 0; i < 2; ++i) {
          if (i == 0)
             glProgramUniform2f(programBlur.getId(), 1, 1, 0);
          else
             glProgramUniform2f(programBlur.getId(), 1, 0, 1);
-         for (int j = 0; j < 100; ++j) {
+         for (int j = 0; j < 1; ++j) {
             GLuint fbo = fbos[(loop % 2) + 1];
             GLuint attach = attachs[loop ? ((loop + 1) % 2 + 1) : 0];
             glBindFramebuffer(GL_FRAMEBUFFER, fbo);
@@ -295,6 +308,62 @@ void RendererGL::render(glm::mat4 proj_mat, glm::mat4 view_mat) {
    glBindTextureUnit(1, attachs[2]);
    glBindTextureUnit(2, attachs[3]);
    glDrawArrays(GL_TRIANGLES, 0, 3);
+}
+
+std::vector<float> RendererGL::gaussKernel(const float sigma,
+                                           const int halfwidth) {
+   float sigma_factor = 1.0 / (sigma * sqrt(2 * glm::pi<float>()));
+
+   auto sigma_fun = [sigma, sigma_factor, n = 0]() mutable {
+      float sigma_val =
+          sigma_factor * glm::exp(-glm::pow(static_cast<float>(n), 2) /
+                                  (2 * glm::pow(sigma, 2)));
+      n++;
+      return sigma_val;
+   };
+
+   std::vector<float> result(halfwidth);
+   std::generate(result.begin(), result.end(), sigma_fun);
+
+   // Normalize the Gaussian kernel
+   float halfnorm = std::accumulate(result.begin() + 1, result.end(), 0.0);
+   float norm = 2 * halfnorm + result[0];
+
+   std::transform(result.begin(), result.end(), result.begin(),
+                  [&norm](auto &val) { return val / norm; });
+
+   return result;
+}
+
+std::pair<std::vector<float>, std::vector<float>> RendererGL::optimGaussKernel(
+    const std::vector<float> weightsIn) {
+   const int inSize = weightsIn.size();
+   const int outSize = (inSize / 2) + 1;
+
+   std::vector<float> offsetsIn(inSize);
+   std::iota(offsetsIn.begin(), offsetsIn.end(), 0);
+
+   std::vector<float> offsetsOut(outSize);
+   std::vector<float> weightsOut(outSize);
+
+   // Centre point of gaussian doesn't change
+   offsetsOut[0] = offsetsIn[0];  // 0.0
+   weightsOut[0] = weightsIn[0];
+
+   // Convert pairs of neighbouring texel weights into a single
+   // weight linearly interpolated between texels. Take care of
+   // possible last lone weight.
+   for (int i = 1; i < outSize; i++) {
+      weightsOut[i] = weightsIn[i * 2 - 1];
+      offsetsOut[i] = offsetsIn[i * 2 - 1];
+      if (i * 2 < inSize) {
+         weightsOut[i] += weightsIn[i * 2];
+         offsetsOut[i] = (offsetsIn[i * 2 - 1] * weightsIn[i * 2 - 1] +
+                          offsetsIn[i * 2] * weightsIn[i * 2]) /
+                         weightsOut[i];
+      }
+   }
+   return std::make_pair(offsetsOut, weightsOut);
 }
 
 void RendererGL::destroy() {}

--- a/src/renderer_gl.hpp
+++ b/src/renderer_gl.hpp
@@ -47,6 +47,13 @@ class RendererGL : public Renderer {
    // Send data obtained from simulation to a buffer
    void setParticleData(const GLuint buffer, const ParticleData &data);
 
+   // Compute the 1D gaussian kernel for given sigma & halfwidth
+   static std::vector<float> gaussKernel(const float sigma, const int halfwidth);
+
+   // Optimizes the given 1D gaussian kernel via texel linear interp
+   static std::pair<std::vector<float>, std::vector<float>> optimGaussKernel(
+       const std::vector<float> inKernel);
+
    Simulator *sim{nullptr};
 
    GLuint flareTex;         ///< Texture for the star flare

--- a/src/simulator.cuh
+++ b/src/simulator.cuh
@@ -36,10 +36,11 @@ namespace simulation {
    typedef float coords_t;
 
    struct vec3 {
-      coords_t x;
-      coords_t y;
-      coords_t z;
+      coords_t x = 0.0;
+      coords_t y = 0.0;
+      coords_t z = 0.0;
 
+      HOSTDEV vec3() {};
       HOSTDEV vec3(coords_t x_, coords_t y_, coords_t z_)
           : x{x_}, y{y_}, z{z_} {}
 
@@ -83,11 +84,10 @@ namespace simulation {
 
    // Simply holds 3 coords_t* as a SoA
    struct ParticleData_d {
-      coords_t *x;
-      coords_t *y;
-      coords_t *z;
+      coords_t *x = nullptr;
+      coords_t *y = nullptr;
+      coords_t *z = nullptr;
 
-      ParticleData_d() = delete;
       ParticleData_d(size_t n) {
          // Allocate device memory for particle coords & velocity...
          gpuErrchk(cudaMalloc((void **)&x, sizeof(coords_t) * n));
@@ -125,7 +125,6 @@ namespace simulation {
 
    class DiskGalaxySimulator : public Simulator {
      public:
-      // DiskGalaxySimulator() = delete; // no default ctor
       DiskGalaxySimulator(SimParam params_);
 
       void stepSim();


### PR DESCRIPTION
I've replaced the previously hardcoded 9-tap optimized blur with
functions which enable defining arbitrary Gaussian kernels with a sigma value & blur
window. The offsets & weights for this are calculated once during
setup, then sent to static array uniforms for the shader.

By setting a high sigma (10.0) & wide window (49), we can achieve good
blurring in a single iteration. In other words, the 'ping-pong' now
only really ping-pongs once (for each blur direction).