### PR TITLE
Make some changes to ease SYCL deployment on DPC++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,17 @@
 
 cmake_minimum_required (VERSION 3.16)
 
-project (nbody LANGUAGES CXX CUDA)
+project (nbody LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(BUILD_SYCL OFF CACHE STRING "")
+option(BUILD_SYCL "whether to build SYCL" OFF)
+
 if(BUILD_SYCL)
         add_subdirectory(src_sycl)
 else()
+	enable_language(CUDA)
         add_subdirectory(src)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The DPC++ compatibility tool offers options for intercepting complex builds, but
 ### CMake
 
 The option `-DBUILD_SYCL` switches between building the CUDA version & the SYCL version of the code.
+When compiling SYCL with `dpcpp`, `MKL_DIR` can be set to point to the `MKLConfig.cmake` file, this defaults to `/opt/intel/oneapi/mkl/latest/lib/cmake/mkl`.
+Environment variables must be set by sourcing `setvars.sh` located at `/opt/intel/oneapi/setvars.sh`.
 
 ## Passing data between OpenGL & CUDA/SYCL
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ The DPC++ compatibility tool offers options for intercepting complex builds, but
 ### CMake
 
 The option `-DBUILD_SYCL` switches between building the CUDA version & the SYCL version of the code.
-When compiling SYCL with `dpcpp`, `MKL_DIR` can be set to point to the `MKLConfig.cmake` file, this defaults to `/opt/intel/oneapi/mkl/latest/lib/cmake/mkl`.
-Environment variables must be set by sourcing `setvars.sh` located at `/opt/intel/oneapi/setvars.sh`.
 
 ## Passing data between OpenGL & CUDA/SYCL
 

--- a/src_sycl/CMakeLists.txt
+++ b/src_sycl/CMakeLists.txt
@@ -1,10 +1,10 @@
-find_package(GLM REQUIRED)
-find_package(GLFW REQUIRED)
-find_package(GLEW REQUIRED)
-set(OpenGL_GL_PREFERENCE GLVND)
-find_package(OpenGL REQUIRED)
+find_package(PkgConfig REQUIRED)
 
-find_package(CUDA REQUIRED)
+pkg_check_modules(Glew REQUIRED IMPORTED_TARGET glew)
+
+find_package(glm REQUIRED)
+find_package(glfw3 REQUIRED)
+find_package(OpenGL REQUIRED)
 
 set(COMMON_SOURCE 
 	nbody.cpp 
@@ -24,13 +24,8 @@ target_compile_definitions(nbodygl PRIVATE -DUSE_OPENGL)
 target_compile_features(nbodygl PRIVATE cxx_auto_type cxx_nullptr cxx_range_for)
 
 target_include_directories(nbodygl PRIVATE
-	${GLM_INCLUDE_DIRS}
-	${GLFW_INCLUDE_DIR}
-	${GLEW_INCLUDE_DIR}
-	${OPENGL_INCLUDE_DIR}
-            ${CUDA_INCLUDE_DIRS}
-            ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
 	/opt/intel/oneapi/mkl/2022.0.1/include/
 	)
 
-target_link_libraries(nbodygl PRIVATE ${GLFW_LIBRARIES} ${GLEW_LIBRARY} ${OPENGL_LIBRARY})
+target_link_libraries(nbodygl PRIVATE glm::glm glfw PkgConfig::Glew OpenGL::OpenGL)

--- a/src_sycl/CMakeLists.txt
+++ b/src_sycl/CMakeLists.txt
@@ -6,6 +6,9 @@ find_package(glm REQUIRED)
 find_package(glfw3 REQUIRED)
 find_package(OpenGL REQUIRED)
 
+set(MKL_DIR CACHE STRING "/opt/intel/oneapi/mkl/latest/lib/cmake/mkl")
+find_package(MKL REQUIRED)
+
 set(COMMON_SOURCE 
 	nbody.cpp 
 	camera.cpp 
@@ -23,9 +26,6 @@ target_compile_definitions(nbodygl PRIVATE -DUSE_OPENGL)
 
 target_compile_features(nbodygl PRIVATE cxx_auto_type cxx_nullptr cxx_range_for)
 
-target_include_directories(nbodygl PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-	/opt/intel/oneapi/mkl/2022.0.1/include/
-	)
+target_include_directories(nbodygl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries(nbodygl PRIVATE glm::glm glfw PkgConfig::Glew OpenGL::OpenGL)
+target_link_libraries(nbodygl PRIVATE glm::glm glfw PkgConfig::Glew OpenGL::OpenGL MKL::MKL)

--- a/src_sycl/CMakeLists.txt
+++ b/src_sycl/CMakeLists.txt
@@ -28,9 +28,7 @@ target_include_directories(nbodygl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(nbodygl PRIVATE glm::glm glfw PkgConfig::Glew OpenGL::OpenGL)
 
 if(CMAKE_CXX_COMPILER MATCHES ".*dpcpp[.exe]*")
-	set(MKL_DIR CACHE STRING "/opt/intel/oneapi/mkl/latest/lib/cmake/mkl")
-	find_package(MKL REQUIRED)
-	target_link_libraries(nbodygl PRIVATE MKL::MKL_DPCPP)
+	target_compile_options(nbodygl PRIVATE -fsycl)
 endif()
 
 

--- a/src_sycl/CMakeLists.txt
+++ b/src_sycl/CMakeLists.txt
@@ -6,9 +6,6 @@ find_package(glm REQUIRED)
 find_package(glfw3 REQUIRED)
 find_package(OpenGL REQUIRED)
 
-set(MKL_DIR CACHE STRING "/opt/intel/oneapi/mkl/latest/lib/cmake/mkl")
-find_package(MKL REQUIRED)
-
 set(COMMON_SOURCE 
 	nbody.cpp 
 	camera.cpp 
@@ -28,4 +25,12 @@ target_compile_features(nbodygl PRIVATE cxx_auto_type cxx_nullptr cxx_range_for)
 
 target_include_directories(nbodygl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries(nbodygl PRIVATE glm::glm glfw PkgConfig::Glew OpenGL::OpenGL MKL::MKL)
+target_link_libraries(nbodygl PRIVATE glm::glm glfw PkgConfig::Glew OpenGL::OpenGL)
+
+if(CMAKE_CXX_COMPILER MATCHES ".*dpcpp[.exe]*")
+	set(MKL_DIR CACHE STRING "/opt/intel/oneapi/mkl/latest/lib/cmake/mkl")
+	find_package(MKL REQUIRED)
+	target_link_libraries(nbodygl PRIVATE MKL::MKL_DPCPP)
+endif()
+
+


### PR DESCRIPTION
I've made the CMake use more modern practices and also included MKL through the appropriate `*Config.cmake` file. Now it's no longer required to add `-fsycl` and other flags to `dpcpp` as the MKL config file will detect dpcpp and add the flags itself.