### PR TITLE
Notes on simulation & symbol rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ A drag factor (`damping`) is used to regulate the velocity. At each timestep, th
 
 The `parameters` described in this section can all be adjusted via command line arguments, as follows:
 
-`./nbodygl numParticles maxIterationsPerFrame damping dt distEps G`
+`./nbodygl numParticles simIterationsPerFrame damping dt distEps G`
 
-Note that `numParicles` specifies the number of particles simulated, divided by blocksize (i.e. setting `numParticles` to 50 produces 50*256 particles). `maxIterationsPerFrame` specifies how many steps of the simulation to take before rendering the next frame. For default values for all of these parameters, refer to `sim_param.cpp`.
+Note that `numParicles` specifies the number of particles simulated, divided by blocksize (i.e. setting `numParticles` to 50 produces 50*256 particles). `simIterationsPerFrame` specifies how many steps of the simulation to take before rendering the next frame. For default values for all of these parameters, refer to `sim_param.cpp`.
 
 ## Graphics Pipeline
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The `parameters` described in this section can all be adjusted via command line 
 
 `./nbodygl numParticles simIterationsPerFrame damping dt distEps G`
 
-Note that `numParicles` specifies the number of particles simulated, divided by blocksize (i.e. setting `numParticles` to 50 produces 50*256 particles). `simIterationsPerFrame` specifies how many steps of the simulation to take before rendering the next frame. For default values for all of these parameters, refer to `sim_param.cpp`.
+Note that `numParticles` specifies the number of particles simulated, divided by blocksize (i.e. setting `numParticles` to 50 produces 50*256 particles). `simIterationsPerFrame` specifies how many steps of the simulation to take before rendering the next frame. For default values for all of these parameters, refer to `sim_param.cpp`.
 
 ### Modifying Simulation Behaviour
 

--- a/src/sim_param.cpp
+++ b/src/sim_param.cpp
@@ -9,7 +9,7 @@ SimParam::SimParam() {
    G = 2.0;
    dt = 0.005;
    numParticles = 50 * 256;
-   maxIterationsPerFrame = 4;
+   simIterationsPerFrame = 4;
    damping = 0.999998;
    distEps = 1.0e-7;
 }
@@ -19,7 +19,7 @@ void SimParam::parseArgs(int argc, char **argv) {
    if (argc >= 2) numParticles = 256 * atoi(argv[1]);
 
    // Second argument if existing = number of iterations per frame
-   if (argc >= 3) maxIterationsPerFrame = atoi(argv[2]);
+   if (argc >= 3) simIterationsPerFrame = atoi(argv[2]);
 
    // Third argument if existing = damping parameter
    if (argc >= 4) damping = atof(argv[3]);

--- a/src/sim_param.hpp
+++ b/src/sim_param.hpp
@@ -25,7 +25,7 @@ class SimParam {
    float G;                    ///< Gravitational parameter
    float dt;                   ///< Simulation delta t
    size_t numParticles;        ///< Number of particles simulated
-   int maxIterationsPerFrame;  ///< Simulation iterations per frame rendered
+   int simIterationsPerFrame;  ///< Simulation iterations per frame rendered
    float damping;  ///< Damping parameter for simulating 'soupy' galaxy (1.0 =
                    ///< no damping)
    float

--- a/src/simulator.cu
+++ b/src/simulator.cu
@@ -42,7 +42,7 @@ namespace simulation {
       // submission until host synchronization. This is more portable via
       // dpct.
       auto start = std::chrono::steady_clock::now();
-      for (size_t i = 0; i < params.maxIterationsPerFrame; i++) {
+      for (size_t i = 0; i < params.simIterationsPerFrame; i++) {
          particle_interaction<<<nblocks, wg_size>>>(pos_d, pos_next_d, vel_d,
                                                     params);
          std::swap(pos_d, pos_next_d);

--- a/src_sycl/sim_param.cpp
+++ b/src_sycl/sim_param.cpp
@@ -9,7 +9,7 @@ SimParam::SimParam() {
    G = 2.0;
    dt = 0.005;
    numParticles = 50 * 256;
-   maxIterationsPerFrame = 4;
+   simIterationsPerFrame = 4;
    damping = 0.999998;
    distEps = 1.0e-7;
 }
@@ -19,7 +19,7 @@ void SimParam::parseArgs(int argc, char **argv) {
    if (argc >= 2) numParticles = 256 * atoi(argv[1]);
 
    // Second argument if existing = number of iterations per frame
-   if (argc >= 3) maxIterationsPerFrame = atoi(argv[2]);
+   if (argc >= 3) simIterationsPerFrame = atoi(argv[2]);
 
    // Third argument if existing = damping parameter
    if (argc >= 4) damping = atof(argv[3]);

--- a/src_sycl/sim_param.hpp
+++ b/src_sycl/sim_param.hpp
@@ -25,7 +25,7 @@ class SimParam {
    float G;                    ///< Gravitational parameter
    float dt;                   ///< Simulation delta t
    size_t numParticles;        ///< Number of particles simulated
-   int maxIterationsPerFrame;  ///< Simulation iterations per frame rendered
+   int simIterationsPerFrame;  ///< Simulation iterations per frame rendered
    float damping;  ///< Damping parameter for simulating 'soupy' galaxy (1.0 =
                    ///< no damping)
    float

--- a/src_sycl/simulator.dp.cpp
+++ b/src_sycl/simulator.dp.cpp
@@ -47,7 +47,7 @@ namespace simulation {
       // submission until host synchronization. This is more portable via
       // dpct.
       auto start = std::chrono::steady_clock::now();
-      for (size_t i = 0; i < params.maxIterationsPerFrame; i++) {
+      for (size_t i = 0; i < params.simIterationsPerFrame; i++) {
          dpct::get_default_queue().submit([&](sycl::handler &cgh) {
             auto pos_d_ct0 = pos_d;
             auto pos_next_d_ct1 = pos_next_d;


### PR DESCRIPTION
Some more extensive notes in README & rename `maxIterationsPerFrame` to `simIterationsPerFrame`.