### PR TITLE
Fix __frsqrt_rn bug & recover performance gap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ settings.json
 *mp4
 lib/**cpp
 lib/**h
+*fatbin*
+*.ptx
+log*
+.vscode
+nbody_dpcpp
+nbody_cuda
+nbody_computecpp

--- a/scripts/perf_test.sh
+++ b/scripts/perf_test.sh
@@ -18,7 +18,7 @@ Xvfb :99 -screen 0 1920x1080x16 -fbdir /var/tmp &
 # Run the nbody simulation on this screen
 DISPLAY=:99.0 COMPUTECPP_TARGET=host ./nbody_computecpp 50 5 0.999 0.001 1.0e-3 2.0 &
 # DISPLAY=:99.0 SYCL_DEVICE_FILTER=opencl:cpu ./nbody_dpcpp 50 5 0.999 0.001 1.0e-3 2.0 &
-#DISPLAY=:99.0 ./nbody_cuda 250 5 0.999 0.001 1.0e-3 2.0 &
+#DISPLAY=:99.0 ./nbody_cuda 50 5 0.999 0.001 1.0e-3 2.0 &
 
 # To take a screenshot instead of a video (doesn't always work):
 # sleep 2

--- a/scripts/perf_test.sh
+++ b/scripts/perf_test.sh
@@ -12,8 +12,12 @@ rm /var/tmp/Xvfb_screen_0
 # mapping output to /var/tmp/Xvfb_screen_0
 Xvfb :99 -screen 0 1920x1080x16 -fbdir /var/tmp &
 
+#export COMPUTECPP_HOST_THREADS=8
+#export COMPUTECPP_MAX_WORKGROUPS=20
+
 # Run the nbody simulation on this screen
 DISPLAY=:99.0 COMPUTECPP_TARGET=host ./nbody_computecpp 50 5 0.999 0.001 1.0e-3 2.0 &
+# DISPLAY=:99.0 SYCL_DEVICE_FILTER=opencl:cpu ./nbody_dpcpp 50 5 0.999 0.001 1.0e-3 2.0 &
 #DISPLAY=:99.0 ./nbody_cuda 250 5 0.999 0.001 1.0e-3 2.0 &
 
 # To take a screenshot instead of a video (doesn't always work):

--- a/scripts/perf_test.sh
+++ b/scripts/perf_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright (C) 2022 Codeplay Software Limited
+# This work is licensed under the terms of the MIT license.
+# For a copy, see https://opensource.org/licenses/MIT.
+
+# Get rid of any previous virtual frame buffer
+pkill -9 Xvfb
+rm /var/tmp/Xvfb_screen_0
+
+# Create a virtual screen :99.0 with given dimensions & color depth
+# mapping output to /var/tmp/Xvfb_screen_0
+Xvfb :99 -screen 0 1920x1080x16 -fbdir /var/tmp &
+
+# Run the nbody simulation on this screen
+DISPLAY=:99.0 COMPUTECPP_TARGET=host ./nbody_computecpp 50 5 0.999 0.001 1.0e-3 2.0 &
+#DISPLAY=:99.0 ./nbody_cuda 250 5 0.999 0.001 1.0e-3 2.0 &
+
+# To take a screenshot instead of a video (doesn't always work):
+# sleep 2
+# DISPLAY=:99 xwd -root -silent | convert xwd:- png:/tmp/screenshot.png
+
+# Use the x11grab device to write to video file
+ffmpeg -video_size 1920x1080 -framerate 25 -f x11grab -i :99.0+0,0 output.mp4

--- a/scripts/perf_test.sh
+++ b/scripts/perf_test.sh
@@ -17,7 +17,8 @@ Xvfb :99 -screen 0 1920x1080x16 -fbdir /var/tmp &
 
 # Run the nbody simulation on this screen
 DISPLAY=:99.0 COMPUTECPP_TARGET=host ./nbody_computecpp 50 5 0.999 0.001 1.0e-3 2.0 &
-# DISPLAY=:99.0 SYCL_DEVICE_FILTER=opencl:cpu ./nbody_dpcpp 50 5 0.999 0.001 1.0e-3 2.0 &
+#DISPLAY=:99.0 SYCL_DEVICE_FILTER=opencl:cpu ./nbody_dpcpp 50 5 0.999 0.001 1.0e-3 2.0 &
+#DISPLAY=:99.0 SYCL_DEVICE_FILTER=cuda ./nbody_dpcpp 50 5 0.999 0.001 1.0e-3 2.0 &
 #DISPLAY=:99.0 ./nbody_cuda 50 5 0.999 0.001 1.0e-3 2.0 &
 
 # To take a screenshot instead of a video (doesn't always work):

--- a/scripts/perf_test_cuda.sh
+++ b/scripts/perf_test_cuda.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright (C) 2022 Codeplay Software Limited
+# This work is licensed under the terms of the MIT license.
+# For a copy, see https://opensource.org/licenses/MIT.
+
+# Get rid of any previous virtual frame buffer
+pkill -9 Xvfb
+rm /var/tmp/Xvfb_screen_0
+
+# Create a virtual screen :99.0 with given dimensions & color depth
+# mapping output to /var/tmp/Xvfb_screen_0
+Xvfb :99 -screen 0 1920x1080x16 -fbdir /var/tmp &
+
+#export COMPUTECPP_HOST_THREADS=8
+#export COMPUTECPP_MAX_WORKGROUPS=20
+
+# Run the nbody simulation on this screen
+#DISPLAY=:99.0 COMPUTECPP_TARGET=host ./nbody_computecpp 50 5 0.999 0.001 1.0e-3 2.0 &
+#DISPLAY=:99.0 SYCL_DEVICE_FILTER=opencl:cpu ./nbody_dpcpp 50 5 0.999 0.001 1.0e-3 2.0 &
+#DISPLAY=:99.0 SYCL_DEVICE_FILTER=cuda ./nbody_dpcpp 50 5 0.999 0.001 1.0e-3 2.0 &
+DISPLAY=:99.0 ./nbody_cuda 50 5 0.999 0.001 1.0e-3 2.0

--- a/scripts/perf_test_dpcpp.sh
+++ b/scripts/perf_test_dpcpp.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright (C) 2022 Codeplay Software Limited
+# This work is licensed under the terms of the MIT license.
+# For a copy, see https://opensource.org/licenses/MIT.
+
+# Get rid of any previous virtual frame buffer
+pkill -9 Xvfb
+rm /var/tmp/Xvfb_screen_0
+
+# Create a virtual screen :99.0 with given dimensions & color depth
+# mapping output to /var/tmp/Xvfb_screen_0
+Xvfb :99 -screen 0 1920x1080x16 -fbdir /var/tmp &
+
+#export COMPUTECPP_HOST_THREADS=8
+#export COMPUTECPP_MAX_WORKGROUPS=20
+
+# Run the nbody simulation on this screen
+#DISPLAY=:99.0 COMPUTECPP_TARGET=host ./nbody_computecpp 50 5 0.999 0.001 1.0e-3 2.0 &
+#DISPLAY=:99.0 SYCL_DEVICE_FILTER=opencl:cpu ./nbody_dpcpp 50 5 0.999 0.001 1.0e-3 2.0 &
+DISPLAY=:99.0 SYCL_DEVICE_FILTER=cuda ./nbody_dpcpp 50 5 0.999 0.001 1.0e-3 2.0
+#DISPLAY=:99.0 ./nbody_cuda 50 5 0.999 0.001 1.0e-3 2.0 &

--- a/scripts/run_dpct_native.sh
+++ b/scripts/run_dpct_native.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (C) 2022 Codeplay Software Limited
+# This work is licensed under the terms of the MIT license.
+# For a copy, see https://opensource.org/licenses/MIT.
+
+# This script converts the project's CUDA code to SYCL code. The DPC++ compatibility tool offers options
+# for intercepting complex builds, but current dev environment restrictions require me to run dpct inside
+# a docker container. This complicates things, so for now I'm just doing single source conversion on the 
+# simulator.cu file.
+#
+# The option --assume-nd-range-dim=1 prevents dpct from converting CUDA 1D ranges into SYCL 3D ranges.
+# It's not totally clear why the default behaviour isn't just to keep the CUDA dimensionality.
+#
+# The custom helper header files referred to by the --use-custom-helper flag are already part of this repo
+# and have been modified for ComputeCpp compatibility. As such, we suppress generation of new helper
+# headers when calling dpct with `--use-custom-helper=none`.
+
+export NBODY_DIR=$PWD
+
+cd $NBODY_DIR
+
+rm src_sycl/*.[ch]pp src_sycl/*.yaml
+cp -r src/*[ch]pp src_sycl/
+#cp -r src/*cpp src_sycl/
+
+dpct --out-root=./src_sycl \
+    --assume-nd-range-dim=1 \
+    --use-custom-helper=none \
+    --stop-on-parse-err \
+    --sycl-named-lambda \
+    ./src/simulator.cu
+
+sed -i 's/simulator.cuh/simulator.dp.hpp/g' src_sycl/renderer.hpp
+sed -i 's/simulator.cuh/simulator.dp.hpp/g' src_sycl/nbody.cpp
+
+# -p=/nbody/build \
+# --optimize-migration

--- a/src/nbody.cpp
+++ b/src/nbody.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
                        [&](const float time) {
                           accum += std::pow((time - meanTime), 2);
                        });
-         float stdDev = accum / stepTimes.size();
+         float stdDev = std::pow(accum / stepTimes.size(), 0.5);
          std::cout << "At step " << stepCounter << " kernel time is "
                    << stepTimes.back() << " and mean is "
                    << cumStepTime / stepTimes.size()

--- a/src/nbody.cpp
+++ b/src/nbody.cpp
@@ -74,6 +74,9 @@ int main(int argc, char **argv) {
 
    float last_fps{0};
 
+   int stepCounter{0};
+   float cumStepTime{0.0};
+
    // Main loop
    while (!glfwWindowShouldClose(window) &&
           glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_RELEASE) {
@@ -84,6 +87,13 @@ int main(int argc, char **argv) {
       renderer.render(camera.getProj(width, height), camera.getView());
       renderer.printKernelTime(nbodySim.getLastStepTime());
 
+      auto stepTime = nbodySim.getLastStepTime();
+      stepCounter++;
+      cumStepTime += stepTime;
+
+      std::cout << "At step " << stepCounter << " kernel time is " << stepTime
+                << " and mean is " << cumStepTime / stepCounter << "\n";
+      
       // Window refresh
       glfwSwapBuffers(window);
       glfwPollEvents();

--- a/src/nbody.cpp
+++ b/src/nbody.cpp
@@ -14,6 +14,8 @@
 #include <iostream>
 #include <thread>
 #include <vector>
+#include <numeric>
+#include <algorithm>
 
 #include "camera.hpp"
 #include "gen.hpp"
@@ -74,8 +76,8 @@ int main(int argc, char **argv) {
 
    float last_fps{0};
 
+   std::vector<float> stepTimes;
    int stepCounter{0};
-   float cumStepTime{0.0};
 
    // Main loop
    while (!glfwWindowShouldClose(window) &&
@@ -87,13 +89,24 @@ int main(int argc, char **argv) {
       renderer.render(camera.getProj(width, height), camera.getView());
       renderer.printKernelTime(nbodySim.getLastStepTime());
 
-      auto stepTime = nbodySim.getLastStepTime();
       stepCounter++;
-      cumStepTime += stepTime;
-
-      std::cout << "At step " << stepCounter << " kernel time is " << stepTime
-                << " and mean is " << cumStepTime / stepCounter << "\n";
-      
+      int warmSteps{2};
+      if (stepCounter > warmSteps) {
+         stepTimes.push_back(nbodySim.getLastStepTime());
+         float cumStepTime =
+             std::accumulate(stepTimes.begin(), stepTimes.end(), 0.0);
+         float meanTime = cumStepTime / stepTimes.size();
+         float accum{0.0};
+         std::for_each(stepTimes.begin(), stepTimes.end(),
+                       [&](const float time) {
+                          accum += std::pow((time - meanTime), 2);
+                       });
+         float stdDev = accum / stepTimes.size();
+         std::cout << "At step " << stepCounter << " kernel time is "
+                   << stepTimes.back() << " and mean is "
+                   << cumStepTime / stepTimes.size()
+                   << " and stddev is: " << stdDev << "\n";
+      }
       // Window refresh
       glfwSwapBuffers(window);
       glfwPollEvents();

--- a/src/simulator.cu
+++ b/src/simulator.cu
@@ -174,8 +174,8 @@ namespace simulation {
       vec3 force(0.0f, 0.0f, 0.0f);
       vec3 pos(pPos.x[id], pPos.y[id], pPos.z[id]);
 
+      #pragma unroll 4
       for (int i = 0; i < params.numParticles; i++) {
-         if (i == id) continue;
          vec3 other_pos{pPos.x[i], pPos.y[i], pPos.z[i]};
          vec3 r = other_pos - pos;
          // Fast computation of 1/(|r|^3)
@@ -183,7 +183,7 @@ namespace simulation {
          coords_t inv_dist_cube = rsqrt(dist_sqr * dist_sqr * dist_sqr);
 
          // assume uniform unit mass
-         force += r * inv_dist_cube;
+         force += r * inv_dist_cube * (i != id);
       }
 
       // Update velocity

--- a/src/simulator.cu
+++ b/src/simulator.cu
@@ -171,7 +171,7 @@ namespace simulation {
       int id = threadIdx.x + (blockIdx.x * blockDim.x);
       if (id >= params.numParticles) return;
 
-      vec3 force(0.0, 0.0, 0.0);
+      vec3 force(0.0f, 0.0f, 0.0f);
       vec3 pos(pPos.x[id], pPos.y[id], pPos.z[id]);
 
       for (int i = 0; i < params.numParticles; i++) {
@@ -180,7 +180,7 @@ namespace simulation {
          vec3 r = other_pos - pos;
          // Fast computation of 1/(|r|^3)
          coords_t dist_sqr = dot(r, r) + params.distEps;
-         coords_t inv_dist_cube = __frsqrt_rn(dist_sqr * dist_sqr * dist_sqr);
+         coords_t inv_dist_cube = rsqrt(dist_sqr * dist_sqr * dist_sqr);
 
          // assume uniform unit mass
          force += r * inv_dist_cube;

--- a/src_sycl/CMakeLists.txt
+++ b/src_sycl/CMakeLists.txt
@@ -60,7 +60,15 @@ else() #DPCPP
 
 	option(DPCPP_CUDA_SUPPORT "on")
 	if(DPCPP_CUDA_SUPPORT)
-		set(SYCL_FLAGS -fsycl -fsycl-targets=spir64,nvptx64-nvidia-cuda -fsycl-unnamed-lambda -O3 -Xsycl-target-frontend=nvptx64-nvidia-cuda -fgpu-inline-threshold=100000 -Xsycl-target-frontend=nvptx64-nvidia-cuda -O3 )
+		set(SYCL_FLAGS -fsycl
+                  -fsycl-targets=spir64,nvptx64-nvidia-cuda
+                  -fsycl-unnamed-lambda
+                  -O3
+                  -Xsycl-target-frontend=nvptx64-nvidia-cuda -fgpu-inline-threshold=100000
+                  -Xsycl-target-frontend=nvptx64-nvidia-cuda -O3
+                  -ffast-math
+                  -ffp-contract=fast
+                  -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_86)
 	else()
 		set(SYCL_FLAGS -fsycl -fsycl-targets=spir64 -fsycl-unnamed-lambda)
 	endif()

--- a/src_sycl/CMakeLists.txt
+++ b/src_sycl/CMakeLists.txt
@@ -60,7 +60,7 @@ else() #DPCPP
 
 	option(DPCPP_CUDA_SUPPORT "on")
 	if(DPCPP_CUDA_SUPPORT)
-		set(SYCL_FLAGS -fsycl -fsycl-targets=spir64,nvptx64-nvidia-cuda -fsycl-unnamed-lambda)
+		set(SYCL_FLAGS -fsycl -fsycl-targets=spir64,nvptx64-nvidia-cuda -fsycl-unnamed-lambda -O3 -Xsycl-target-frontend=nvptx64-nvidia-cuda -fgpu-inline-threshold=100000 -Xsycl-target-frontend=nvptx64-nvidia-cuda -O3 )
 	else()
 		set(SYCL_FLAGS -fsycl -fsycl-targets=spir64 -fsycl-unnamed-lambda)
 	endif()

--- a/src_sycl/nbody.cpp
+++ b/src_sycl/nbody.cpp
@@ -107,7 +107,6 @@ int main(int argc, char **argv) {
                    << cumStepTime / stepTimes.size()
                    << " and stddev is: " << stdDev << "\n";
       }
-
       // Window refresh
       glfwSwapBuffers(window);
       glfwPollEvents();

--- a/src_sycl/nbody.cpp
+++ b/src_sycl/nbody.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
                        [&](const float time) {
                           accum += std::pow((time - meanTime), 2);
                        });
-         float stdDev = accum / stepTimes.size();
+         float stdDev = std::pow(accum / stepTimes.size(), 0.5);
          std::cout << "At step " << stepCounter << " kernel time is "
                    << stepTimes.back() << " and mean is "
                    << cumStepTime / stepTimes.size()

--- a/src_sycl/nbody.cpp
+++ b/src_sycl/nbody.cpp
@@ -74,6 +74,9 @@ int main(int argc, char **argv) {
 
    float last_fps{0};
 
+   int stepCounter{0};
+   float cumStepTime{0.0};
+
    // Main loop
    while (!glfwWindowShouldClose(window) &&
           glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_RELEASE) {
@@ -84,6 +87,13 @@ int main(int argc, char **argv) {
       renderer.render(camera.getProj(width, height), camera.getView());
       renderer.printKernelTime(nbodySim.getLastStepTime());
 
+      auto stepTime = nbodySim.getLastStepTime();
+      stepCounter++;
+      cumStepTime += stepTime;
+
+      std::cout << "At step " << stepCounter << " kernel time is " << stepTime
+                << " and mean is " << cumStepTime / stepCounter << "\n";
+      
       // Window refresh
       glfwSwapBuffers(window);
       glfwPollEvents();

--- a/src_sycl/simulator.dp.cpp
+++ b/src_sycl/simulator.dp.cpp
@@ -285,15 +285,14 @@ namespace simulation {
       vec3 force(0.0f, 0.0f, 0.0f);
       vec3 pos(pPos.x[id], pPos.y[id], pPos.z[id]);
 
-      #pragma unroll 32
+      #pragma unroll 4
       for (int i = 0; i < params.numParticles; i++) {
-         if (i == id) continue;
          vec3 other_pos{pPos.x[i], pPos.y[i], pPos.z[i]};
          vec3 r = other_pos - pos;
          // Fast computation of 1/(|r|^3)
          coords_t dist_sqr = dot(r, r) + params.distEps;
          coords_t inv_dist_cube =
-             sycl::rsqrt(dist_sqr * dist_sqr * dist_sqr);
+             sycl::rsqrt((double)dist_sqr * dist_sqr * dist_sqr);
 
          // assume uniform unit mass
          /*
@@ -301,7 +300,7 @@ namespace simulation {
          different template instantiations that could not be unified. You may
          need to adjust the code.
          */
-         force += r * inv_dist_cube;
+         force += r * inv_dist_cube * (i != id);
       }
 
       // Update velocity

--- a/src_sycl/simulator.dp.cpp
+++ b/src_sycl/simulator.dp.cpp
@@ -52,7 +52,7 @@ namespace simulation {
             auto params_ct3 = params;
 
             cgh.parallel_for<
-                dpct_kernel_name<class particle_interaction_a6ec79>>(
+                dpct_kernel_name<class particle_interaction_18c029>>(
                 sycl::nd_range<1>(
                     sycl::range<1>(nblocks) * sycl::range<1>(wg_size),
                     sycl::range<1>(wg_size)),
@@ -279,10 +279,10 @@ namespace simulation {
                                         ParticleData_d pVel, SimParam params,
                                         sycl::nd_item<1> item_ct1) {
       int id = item_ct1.get_local_id(0) +
-               (item_ct1.get_group(0) * item_ct1.get_local_range().get(0));
+               (item_ct1.get_group(0) * item_ct1.get_local_range(0));
       if (id >= params.numParticles) return;
 
-      vec3 force(0.0, 0.0, 0.0);
+      vec3 force(0.0f, 0.0f, 0.0f);
       vec3 pos(pPos.x[id], pPos.y[id], pPos.z[id]);
 
       for (int i = 0; i < params.numParticles; i++) {
@@ -291,17 +291,12 @@ namespace simulation {
          vec3 r = other_pos - pos;
          // Fast computation of 1/(|r|^3)
          coords_t dist_sqr = dot(r, r) + params.distEps;
-         /*
-         DPCT1013:20: The rounding mode could not be specified and the generated
-         code may have different precision then the original code. Verify the
-         correctness. SYCL math built-ins rounding mode is aligned with OpenCL
-         C 1.2 standard.
-         */
-         coords_t inv_dist_cube = sycl::rsqrt(dist_sqr * dist_sqr * dist_sqr);
+         coords_t inv_dist_cube =
+             sycl::rsqrt((double)dist_sqr * dist_sqr * dist_sqr);
 
          // assume uniform unit mass
          /*
-         DPCT1084:21: The function call has multiple migration results in
+         DPCT1084:20: The function call has multiple migration results in
          different template instantiations that could not be unified. You may
          need to adjust the code.
          */
@@ -312,7 +307,7 @@ namespace simulation {
       vec3 curr_vel(pVel.x[id], pVel.y[id], pVel.z[id]);
       curr_vel *= params.damping;
       /*
-      DPCT1084:22: The function call has multiple migration results in different
+      DPCT1084:21: The function call has multiple migration results in different
       template instantiations that could not be unified. You may need to adjust
       the code.
       */
@@ -326,7 +321,7 @@ namespace simulation {
       vec3 curr_pos(pPos.x[id], pPos.y[id], pPos.z[id]);
 
       /*
-      DPCT1084:23: The function call has multiple migration results in different
+      DPCT1084:22: The function call has multiple migration results in different
       template instantiations that could not be unified. You may need to adjust
       the code.
       */

--- a/src_sycl/simulator.dp.cpp
+++ b/src_sycl/simulator.dp.cpp
@@ -285,6 +285,7 @@ namespace simulation {
       vec3 force(0.0f, 0.0f, 0.0f);
       vec3 pos(pPos.x[id], pPos.y[id], pPos.z[id]);
 
+      #pragma unroll 32
       for (int i = 0; i < params.numParticles; i++) {
          if (i == id) continue;
          vec3 other_pos{pPos.x[i], pPos.y[i], pPos.z[i]};

--- a/src_sycl/simulator.dp.cpp
+++ b/src_sycl/simulator.dp.cpp
@@ -292,7 +292,7 @@ namespace simulation {
          // Fast computation of 1/(|r|^3)
          coords_t dist_sqr = dot(r, r) + params.distEps;
          coords_t inv_dist_cube =
-             sycl::rsqrt((double)dist_sqr * dist_sqr * dist_sqr);
+             sycl::rsqrt(dist_sqr * dist_sqr * dist_sqr);
 
          // assume uniform unit mass
          /*


### PR DESCRIPTION
This repo previously reported *faster* performance from SYCL than CUDA, but this was due to an erroneous translation in DPCT from `__frsqrt_rn` to `sycl::rsqrt`. The former has higher precision and runs slower than the latter. This has now been rectified so that the original CUDA code calls `rsqrt`.

With this bug rectified, and without any further modification to the CUDA code or dpct-generated SYCL code, the SYCL code is considerably slower because DPCT inserts a cast to double in the rsqrt call:

```
         coords_t inv_dist_cube =
             sycl::rsqrt((double)dist_sqr * dist_sqr * dist_sqr);
```

This is presumably because DPCT is unsure of the equivalence of `rsqrt` and `sycl::rsqrt`. However, inspecting PTX reveals that the generated instructions are the same, so the cast to double is unnecessary. Removing the cast to double leaves a 40% performance gap between CUDA and SYCL.

The root cause of this 40% performance gap appears to be different handling of the branch instruction:

```
if (i == id) continue;
```
in the main loop in simulation.dp.cpp. Whereas NVCC handles this via instruction predication, DPC++ generates branch & sync instructions. By replacing this branch instruction with an arithemtic:

```
force += r * inv_dist_cube * (i != id);
```
in both the CUDA & SYCL code, we get the same performance between the two. For 5 steps of the physical simulation (1 rendered frame) with 12,800 particles, both CUDA and SYCL take ~5.05ms (RTX 3060).