### PR TITLE
Device info & improved overlay

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,10 +24,11 @@ set(OPENGL_SOURCE
 
 add_executable(${BINARY_NAME} ${COMMON_SOURCE} ${OPENGL_SOURCE})
 
-target_compile_definitions(${BINARY_NAME} PRIVATE -DUSE_OPENGL)
+# COMPILER_NAME here is only used to print text overlay on simulation
+target_compile_definitions(${BINARY_NAME} PRIVATE -DUSE_OPENGL COMPILER_NAME="CUDA")
 
 target_compile_features(${BINARY_NAME} PRIVATE cxx_auto_type cxx_nullptr cxx_range_for)
 
 target_include_directories(${BINARY_NAME} PRIVATE ${CUDA_INCLUDE_DIRS})
 
-target_link_libraries(${BINARY_NAME} PRIVATE glm::glm glfw PkgConfig::Glew OpenGL::OpenGL)
+target_link_libraries(${BINARY_NAME} PRIVATE glm::glm glfw PkgConfig::Glew OpenGL::OpenGL cuda)

--- a/src/nbody.cpp
+++ b/src/nbody.cpp
@@ -80,6 +80,8 @@ int main(int argc, char **argv) {
    int stepCounter{0};
 
    // Main loop
+   unsigned int counter = 0;
+   float stepTime = 0.0;
    while (!glfwWindowShouldClose(window) &&
           glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_RELEASE) {
       double frame_start = glfwGetTime();
@@ -87,7 +89,8 @@ int main(int argc, char **argv) {
       nbodySim.stepSim();
       renderer.updateParticles();
       renderer.render(camera.getProj(width, height), camera.getView());
-      renderer.printKernelTime(nbodySim.getLastStepTime());
+      if(!(counter % 20)) stepTime = nbodySim.getLastStepTime();
+      renderer.printKernelTime(stepTime);
 
       stepCounter++;
       int warmSteps{2};
@@ -115,6 +118,7 @@ int main(int argc, char **argv) {
       double frame_end = glfwGetTime();
       double elapsed = frame_end - frame_start;
       last_fps = 1.0 / elapsed;
+      counter++;
    }
    renderer.destroy();
    glfwDestroyWindow(window);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -139,7 +139,9 @@ void RendererGL::printKernelTime(float kernelTime) {
                     ImGuiWindowFlags_NoScrollbar |
                     ImGuiWindowFlags_NoSavedSettings |
                     ImGuiWindowFlags_NoInputs);
-   ImGui::SetWindowFontScale(1.8);
+   ImGui::SetWindowFontScale(2.5);
+   ImGui::Text("%s", (std::string("N-body demo running with " COMPILER_NAME
+                                  " on device: ") + *sim->getDeviceName()).c_str());
    if (PRINT_PSEUDO_FPS) {
       ImGui::Text("FPS: %2.0f", 1000.0/kernelTime);
    } else {

--- a/src/simulator.cu
+++ b/src/simulator.cu
@@ -31,6 +31,17 @@ namespace simulation {
       sendToDevice();
    };
 
+   const std::string* DiskGalaxySimulator::getDeviceName() {
+     // Query the device first time only
+     if(devName.empty()){
+       char devNameHolder[256];
+       int error_id = cuDeviceGetName(devNameHolder, 256, 0); // Assume main device
+       if(error_id != CUDA_SUCCESS) devName = "Unknown Device";
+         else devName = devNameHolder;
+     }
+     return &devName;
+   }
+
    void DiskGalaxySimulator::stepSim() {
       // Compute updated positions
       constexpr int wg_size = 256;

--- a/src/simulator.cuh
+++ b/src/simulator.cuh
@@ -8,6 +8,7 @@
 #include <cuda_runtime_api.h>
 #include <stdio.h>
 
+#include <string>
 #include <vector>
 
 #include "sim_param.hpp"
@@ -110,6 +111,7 @@ namespace simulation {
       virtual const ParticleData &getParticlePos() = 0;
       virtual const ParticleData &getParticleVel() = 0;
       virtual float getLastStepTime() = 0;
+      virtual const std::string* getDeviceName() = 0;
    };
 
    /*
@@ -132,9 +134,11 @@ namespace simulation {
       size_t getNumParticles() { return params.numParticles; }
       const ParticleData &getParticlePos();
       const ParticleData &getParticleVel();
+      const std::string* getDeviceName();
 
      private:
       SimParam params;
+      std::string devName;
       float lastStepTime{0.0};
 
       // Data for particle positions & vel on host

--- a/src_sycl/CMakeLists.txt
+++ b/src_sycl/CMakeLists.txt
@@ -22,7 +22,7 @@ set(OPENGL_SOURCE
 
 add_executable(${BINARY_NAME} ${COMMON_SOURCE} ${OPENGL_SOURCE})
 
-target_compile_definitions(${BINARY_NAME} PRIVATE -DUSE_OPENGL COMPILER_NAME="DPC++")
+target_compile_definitions(${BINARY_NAME} PRIVATE -DUSE_OPENGL COMPILER_NAME="SYCL")
 
 target_compile_features(${BINARY_NAME} PRIVATE cxx_auto_type cxx_nullptr cxx_range_for)
 

--- a/src_sycl/CMakeLists.txt
+++ b/src_sycl/CMakeLists.txt
@@ -22,7 +22,7 @@ set(OPENGL_SOURCE
 
 add_executable(${BINARY_NAME} ${COMMON_SOURCE} ${OPENGL_SOURCE})
 
-target_compile_definitions(${BINARY_NAME} PRIVATE -DUSE_OPENGL)
+target_compile_definitions(${BINARY_NAME} PRIVATE -DUSE_OPENGL COMPILER_NAME="DPC++")
 
 target_compile_features(${BINARY_NAME} PRIVATE cxx_auto_type cxx_nullptr cxx_range_for)
 

--- a/src_sycl/nbody.cpp
+++ b/src_sycl/nbody.cpp
@@ -80,6 +80,8 @@ int main(int argc, char **argv) {
    int stepCounter{0};
 
    // Main loop
+   unsigned int counter = 0;
+   float stepTime = 0.0;
    while (!glfwWindowShouldClose(window) &&
           glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_RELEASE) {
       double frame_start = glfwGetTime();
@@ -87,7 +89,8 @@ int main(int argc, char **argv) {
       nbodySim.stepSim();
       renderer.updateParticles();
       renderer.render(camera.getProj(width, height), camera.getView());
-      renderer.printKernelTime(nbodySim.getLastStepTime());
+      if(!(counter % 20)) stepTime = nbodySim.getLastStepTime();
+      renderer.printKernelTime(stepTime);
 
       stepCounter++;
       int warmSteps{2};
@@ -115,6 +118,7 @@ int main(int argc, char **argv) {
       double frame_end = glfwGetTime();
       double elapsed = frame_end - frame_start;
       last_fps = 1.0 / elapsed;
+      counter++;
    }
    renderer.destroy();
    glfwDestroyWindow(window);

--- a/src_sycl/renderer_gl.cpp
+++ b/src_sycl/renderer_gl.cpp
@@ -139,7 +139,9 @@ void RendererGL::printKernelTime(float kernelTime) {
                     ImGuiWindowFlags_NoScrollbar |
                     ImGuiWindowFlags_NoSavedSettings |
                     ImGuiWindowFlags_NoInputs);
-   ImGui::SetWindowFontScale(1.8);
+   ImGui::SetWindowFontScale(2.5);
+   ImGui::Text("%s", (std::string("N-body demo running with " COMPILER_NAME
+                                  " on device: ") + *sim->getDeviceName()).c_str());
    if (PRINT_PSEUDO_FPS) {
       ImGui::Text("FPS: %2.0f", 1000.0/kernelTime);
    } else {

--- a/src_sycl/simulator.dp.cpp
+++ b/src_sycl/simulator.dp.cpp
@@ -34,6 +34,27 @@ namespace simulation {
       sendToDevice();
    };
 
+   const std::string* DiskGalaxySimulator::getDeviceName() {
+     // Query the device first time only
+     if(devName.empty()){
+       char devNameHolder[256];
+       /*
+       DPCT1003:4: Migrated API does not return error code. (*, 0) is inserted.
+       You may need to rewrite this code.
+       */
+       int error_id = (memcpy(devNameHolder,
+                              dpct::dev_mgr::instance()
+                                  .get_device(0)
+                                  .get_info<sycl::info::device::name>()
+                                  .c_str(),
+                              256),
+                       0);  // Assume main device
+       if (error_id != 0) devName = "Unknown Device";
+         else devName = devNameHolder;
+     }
+     return &devName;
+   }
+
    void DiskGalaxySimulator::stepSim() {
       // Compute updated positions
       constexpr int wg_size = 256;

--- a/src_sycl/simulator.dp.hpp
+++ b/src_sycl/simulator.dp.hpp
@@ -8,6 +8,7 @@
 #include <dpct/dpct.hpp>
 #include <stdio.h>
 
+#include <string>
 #include <vector>
 
 #include "sim_param.hpp"
@@ -121,6 +122,7 @@ namespace simulation {
       virtual const ParticleData &getParticlePos() = 0;
       virtual const ParticleData &getParticleVel() = 0;
       virtual float getLastStepTime() = 0;
+      virtual const std::string* getDeviceName() = 0;
    };
 
    /*
@@ -143,9 +145,11 @@ namespace simulation {
       size_t getNumParticles() { return params.numParticles; }
       const ParticleData &getParticlePos();
       const ParticleData &getParticleVel();
+      const std::string* getDeviceName();
 
      private:
       SimParam params;
+      std::string devName;
       float lastStepTime{0.0};
 
       // Data for particle positions & vel on host


### PR DESCRIPTION
Two changes:

- only print kernel time every 20 steps (to make it readable)
- print device & compiler info

This is a cherry pick/rebase of two commits from branch `device_info`